### PR TITLE
matchMarketOrder function with fund transfer after match completion

### DIFF
--- a/contracts/OrderBook.sol
+++ b/contracts/OrderBook.sol
@@ -91,6 +91,21 @@ contract OrderBook is IOrderBook, ReentrancyGuard {
     /// This can happen if the maker was blacklisted and no longer is
     event Claimed(address indexed owner, uint256 amount, bool isBaseToken);
 
+    struct OrderMatchFill {
+        bool isAsk;
+        address taker;
+        address maker;
+        uint256 matchAmount0;
+        uint256 matchAmount1;
+    }
+
+    struct MatchOrderLocalVars {
+        uint32 index;
+        uint256 filledAmount0;
+        uint256 filledAmount1; 
+        uint32 orderMatchFillIndex;
+    }
+
     function checkIsRouter() private view {
         require(
             msg.sender == routerAddress,
@@ -231,6 +246,199 @@ contract OrderBook is IOrderBook, ReentrancyGuard {
         _orderIdCounter.increment();
     }
 
+    function matchMarketOrder(
+        LimitOrder memory order,
+        bool isAsk,
+        address from
+    ) public {
+
+        OrderMatchFill[] memory orderMatchFills = new OrderMatchFill[](100);
+        MatchOrderLocalVars memory matchOrderLocalVars;
+
+        if (isAsk) {
+            bool atLeastOneFullSwap = false;
+
+            matchOrderLocalVars.index = bid.getFirstNode();
+            while (matchOrderLocalVars.index != 1 && order.amount0 > 0) {
+                LimitOrder storage bestBid = bid.idToLimitOrder[matchOrderLocalVars.index];
+                (
+                    uint256 swapAmount0,
+                    uint256 swapAmount1
+                ) = getLimitOrderSwapAmounts(order, bestBid, isAsk);
+                // Since the linked list is sorted, if there is no price
+                // overlap on the current order, there will be no price
+                // overlap on the later orders
+                if (swapAmount0 == 0 || swapAmount1 == 0) break;
+
+                emit Swap(
+                    swapAmount0,
+                    swapAmount1,
+                    order.id,
+                    from,
+                    bestBid.id,
+                    bestBid.owner
+                );
+
+                matchOrderLocalVars.filledAmount0 = matchOrderLocalVars.filledAmount0 + swapAmount0;
+                matchOrderLocalVars.filledAmount1 = matchOrderLocalVars.filledAmount1 + swapAmount1;
+
+                OrderMatchFill memory orderMatchFill = OrderMatchFill({
+                    isAsk: true,
+                    taker: from,
+                    maker: bestBid.owner,
+                    matchAmount0: swapAmount0,
+                    matchAmount1: swapAmount1
+                });
+
+                orderMatchFills[matchOrderLocalVars.orderMatchFillIndex] = orderMatchFill;
+                matchOrderLocalVars.orderMatchFillIndex++;
+
+                order.amount1 =
+                    order.amount1 -
+                    (
+                        FullMath.mulDiv(
+                            order.amount1,
+                            swapAmount0,
+                            order.amount0
+                        )
+                    );
+                order.amount0 = order.amount0 - swapAmount0;
+
+                if (bestBid.amount0 == swapAmount0) {
+                    // Remove the best bid from the order book if it is fully
+                    // filled
+                    atLeastOneFullSwap = true;
+                    bid.list[matchOrderLocalVars.index].active = false;
+                    delete bid.idToLimitOrder[bestBid.id];
+                } else {
+                    // Update the best bid if it is partially filled
+                    bestBid.amount0 = bestBid.amount0 - swapAmount0;
+                    bestBid.amount1 = bestBid.amount1 - swapAmount1;
+                    break;
+                }
+
+                matchOrderLocalVars.index = bid.list[matchOrderLocalVars.index].next;
+            }
+            if (atLeastOneFullSwap) {
+                bid.list[matchOrderLocalVars.index].prev = 0;
+                bid.list[0].next = matchOrderLocalVars.index;
+            }
+
+        } else {
+            bool atLeastOneFullSwap = false;
+
+            matchOrderLocalVars.index = ask.getFirstNode();
+            while (matchOrderLocalVars.index != 1 && order.amount1 > 0) {
+                LimitOrder storage bestAsk = ask.idToLimitOrder[matchOrderLocalVars.index];
+                (
+                    uint256 swapAmount0,
+                    uint256 swapAmount1
+                ) = getLimitOrderSwapAmounts(order, bestAsk, isAsk);
+                // Since the linked list is sorted, if there is no price
+                // overlap on the current order, there will be no price
+                // overlap on the later orders
+                if (swapAmount0 == 0 || swapAmount1 == 0) break;
+
+                emit Swap(
+                    swapAmount0,
+                    swapAmount1,
+                    bestAsk.id,
+                    bestAsk.owner,
+                    order.id,
+                    from
+                );
+
+                matchOrderLocalVars.filledAmount0 = matchOrderLocalVars.filledAmount0 + swapAmount0;
+                matchOrderLocalVars.filledAmount1 = matchOrderLocalVars.filledAmount1 + swapAmount1;
+
+                OrderMatchFill memory orderMatchFill = OrderMatchFill({
+                    isAsk: false,
+                    taker: from,
+                    maker: bestAsk.owner,
+                    matchAmount0: swapAmount0,
+                    matchAmount1: swapAmount1
+                });
+
+                orderMatchFills[matchOrderLocalVars.orderMatchFillIndex] = orderMatchFill;
+                matchOrderLocalVars.orderMatchFillIndex++;
+
+                order.amount1 =
+                    order.amount1 -
+                    (
+                        FullMath.mulDiv(
+                            order.amount1,
+                            swapAmount0,
+                            order.amount0
+                        )
+                    );
+                order.amount0 = order.amount0 - swapAmount0;
+
+                if (bestAsk.amount0 == swapAmount0) {
+                    // Remove the best ask from the order book if it is fully
+                    // filled
+                    atLeastOneFullSwap = true;
+                    ask.list[matchOrderLocalVars.index].active = false;
+                    delete ask.idToLimitOrder[bestAsk.id];
+                } else {
+                    // Update the best ask if it is partially filled
+                    bestAsk.amount0 = bestAsk.amount0 - swapAmount0;
+                    bestAsk.amount1 = bestAsk.amount1 - swapAmount1;
+                    break;
+                }
+
+                matchOrderLocalVars.index = ask.list[matchOrderLocalVars.index].next;
+            }
+            if (atLeastOneFullSwap) {
+                ask.list[matchOrderLocalVars.index].prev = 0;
+                ask.list[0].next = matchOrderLocalVars.index;
+            }
+        }
+
+        //execute the order-match fill instructions
+        if(matchOrderLocalVars.orderMatchFillIndex > 0) {
+
+            for(uint ind = 0 ; ind < matchOrderLocalVars.orderMatchFillIndex ; ++ind) {
+
+                OrderMatchFill memory orderMatchFill = orderMatchFills[ind];
+
+                if(orderMatchFill.isAsk) { 
+                    
+                    // for a sell-order, transfer token-0 amount to matched best-bid owner of orderBook
+                    bool success = sendToken(token0, orderMatchFill.maker, orderMatchFill.matchAmount0);
+
+                    if (!success) {
+                        claimableBaseToken[orderMatchFill.maker] += orderMatchFill.matchAmount0;
+                        emit ClaimableBalanceIncrease(
+                            orderMatchFill.maker,
+                            orderMatchFill.matchAmount0,
+                            claimableBaseToken[orderMatchFill.maker],
+                            true
+                        );
+                    }
+
+                    sendTokenSafe(token1, orderMatchFill.taker, orderMatchFill.matchAmount1);
+
+                } else {
+
+                    //Sending tokens to the maker account
+                    bool success = sendToken(token1, orderMatchFill.maker, orderMatchFill.matchAmount1);
+
+                    if (!success) {
+                        claimableQuoteToken[orderMatchFill.maker] += orderMatchFill.matchAmount1;
+                        emit ClaimableBalanceIncrease(
+                            orderMatchFill.maker,
+                            orderMatchFill.matchAmount1,
+                            claimableBaseToken[orderMatchFill.maker],
+                            true
+                        );
+                    }
+
+                    sendTokenSafe(token0, orderMatchFill.maker, orderMatchFill.matchAmount0);
+                }
+            }
+        }
+    }
+
     /// @notice Transfers tokens to sell (base or quote token) to the router contract depending on the size
     /// Matches the new order with existing orders in the order book if there are price overlaps
     /// Does not insert the remaining order into the order book post matching
@@ -239,7 +447,7 @@ contract OrderBook is IOrderBook, ReentrancyGuard {
     /// @param order The limit order to fill
     /// @param isAsk Whether the order is an ask order
     /// @param from The address of the order sender
-    function matchOrder(
+    function matchLimitOrder(
         LimitOrder memory order,
         bool isAsk,
         address from
@@ -444,7 +652,7 @@ contract OrderBook is IOrderBook, ReentrancyGuard {
             isAsk
         );
 
-        matchOrder(newOrder, isAsk, from);
+        matchLimitOrder(newOrder, isAsk, from);
 
         // If the order is not fully filled, insert it into the order book
         if (isAsk) {
@@ -547,14 +755,14 @@ contract OrderBook is IOrderBook, ReentrancyGuard {
             isAsk
         );
 
-        matchOrder(newOrder, isAsk, from);
+        matchMarketOrder(newOrder, isAsk, from);
 
-        // If the order is not fully filled, refund the remaining deposited amount
-        if (isAsk) {
-            sendTokenSafe(token0, from, newOrder.amount0);
-        } else {
-            sendTokenSafe(token1, from, newOrder.amount1);
-        }
+        // // If the order is not fully filled, refund the remaining deposited amount
+        // if (isAsk) {
+        //     sendTokenSafe(token0, from, newOrder.amount0);
+        // } else {
+        //     sendTokenSafe(token1, from, newOrder.amount1);
+        // }
     }
 
     /// @inheritdoc IOrderBook

--- a/contracts/OrderBook.sol
+++ b/contracts/OrderBook.sol
@@ -290,10 +290,7 @@ contract OrderBook is IOrderBook, ReentrancyGuard {
                         true
                     );
                 }
-                    
-                //send matched-amount of token1 from order-book to market-taker
-                sendTokenSafe(token1, from, swapAmount1);
-
+                
                 order.amount1 =
                     order.amount1 -
                     (
@@ -324,7 +321,9 @@ contract OrderBook is IOrderBook, ReentrancyGuard {
                 bid.list[matchOrderLocalVars.index].prev = 0;
                 bid.list[0].next = matchOrderLocalVars.index;
             }
-
+              
+            //send matched-amount of token1 from order-book to market-taker
+            sendTokenSafe(token1, from, matchOrderLocalVars.filledAmount1);
         } else {
             bool atLeastOneFullSwap = false;
 
@@ -369,9 +368,6 @@ contract OrderBook is IOrderBook, ReentrancyGuard {
                         );
                     }
 
-                    //send matched-amount of token0 from order-book to market-taker        
-                    sendTokenSafe(token0, from, swapAmount0);
-
                 order.amount1 =
                     order.amount1 -
                     (
@@ -402,6 +398,9 @@ contract OrderBook is IOrderBook, ReentrancyGuard {
                 ask.list[matchOrderLocalVars.index].prev = 0;
                 ask.list[0].next = matchOrderLocalVars.index;
             }
+
+            //send matched-amount of token0 from order-book to market-taker        
+            sendTokenSafe(token0, from, matchOrderLocalVars.filledAmount0);
         }
     }
 

--- a/contracts/Router.sol
+++ b/contracts/Router.sol
@@ -275,6 +275,18 @@ contract Router is IBalanceChangeCallback {
         );
     }
 
+    /// @notice safeTransfer of funds between sender and recipient
+    /// from can be market-maker or taker and to can be either parties or orderBook
+    /// 
+    function safeTransferFromUser(
+        IERC20Metadata tokenToTransferFrom,
+        address from,
+        address to,
+        uint256 amount
+    ) external override {
+        tokenToTransferFrom.safeTransferFrom(from, to, amount);
+    }
+    
     /// @notice Get the order details of all limit orders in the order book.
     /// Each returned list contains the details of ask orders first, followed
     /// by bid orders

--- a/contracts/interfaces/IBalanceChangeCallback.sol
+++ b/contracts/interfaces/IBalanceChangeCallback.sol
@@ -17,4 +17,14 @@ interface IBalanceChangeCallback {
         uint256 amount,
         uint8 orderBookId
     ) external;
+
+
+    /// safeTransfer of funds between maker and taker
+    function safeTransferFromUser(
+        IERC20Metadata tokenToTransferFrom,
+        address from,
+        address to,
+        uint256 amount
+    ) external;
+
 }

--- a/test/MarketOrder.ts
+++ b/test/MarketOrder.ts
@@ -77,7 +77,7 @@ describe("OrderBook contract, market orders", function () {
     };
   }
 
-  it("Bid-Market-Order match with Ask-Limit-Orders", async function () {
+  it("Bid-Market-Order full-match with Ask-Limit-Orders", async function () {
     const { router, token0, token1, acc1, acc2, sizeTick, priceMultiplier } = await get_setup_values();
     const marketMaker = acc2;
     const marketTaker = acc1;
@@ -87,17 +87,17 @@ describe("OrderBook contract, market orders", function () {
     const token0_balance_bef_limit_order_market_maker = await token0.balanceOf(marketMaker.address);
 
     const orderBookId: number = 0;
-    const amount0base_limit: number = 1;
-    const price0Base_limit: number = 1;
-    const isAsk_limit: number = 1;
+    const amount0base_limit_order: number = 1;
+    const price0Base_limit_order: number = 1;
+    const isAsk_limit_order: number = 1;
     const hintId: number = 0;
 
     // Create 5 ask-limit orders
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 2
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 3
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 4
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 5
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 6
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 2
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 3
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 4
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 5
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 6
 
     const token1_balance_aft_limit_order_market_maker = await token1.balanceOf(marketMaker.address);
     const token0_balance_aft_limit_order_market_maker = await token0.balanceOf(marketMaker.address);
@@ -114,13 +114,13 @@ describe("OrderBook contract, market orders", function () {
     const token1_balance_bef_mkt_order_market_taker = await token1.balanceOf(marketTaker.address);
     const token0_balance_bef_mkt_order_market_taker = await token0.balanceOf(marketTaker.address);
   
-    const amount0base_bid_market: number = 3;
-    const price0Base_bid_market: number = 1;
-    const isAsk_bid_market: number = 0;
+    const amount0base_bid_market_order: number = 3;
+    const price0Base_bid_market_order: number = 1;
+    const isAsk_bid_market_order: number = 0;
 
     // Create bid-market order to fill first 3 limit-ask orders
     // market-order to buy token0 of amount: 3 after including size-tick it will be: 3 * 100 = 300
-    await router.connect(marketTaker).createMarketOrder(orderBookId, amount0base_bid_market, price0Base_bid_market, isAsk_bid_market);
+    await router.connect(marketTaker).createMarketOrder(orderBookId, amount0base_bid_market_order, price0Base_bid_market_order, isAsk_bid_market_order);
 
     let order_ids = await router.getLimitOrders(0);
 
@@ -144,11 +144,86 @@ describe("OrderBook contract, market orders", function () {
     //the balance of token1 for market-maker should increase by 3 amount
     expect(
       (token1_balance_aft_mkt_order_market_maker).eq(
-        BigInt(token1_balance_aft_limit_order_market_maker) + BigInt(3 * amount0base_limit * price0Base_limit * priceMultiplier)
+        BigInt(token1_balance_aft_limit_order_market_maker) + BigInt(3 * amount0base_limit_order * price0Base_limit_order * priceMultiplier)
       )
     ).to.be.true;
 
   });
+
+
+  it("Bid-Market-Order partial-match with Ask-Limit-Orders", async function () {
+    const { router, token0, token1, acc1, acc2, sizeTick, priceMultiplier } = await get_setup_values();
+    const marketMaker = acc2;
+    const marketTaker = acc1;
+    const td = BigInt(1000000); // token decimals
+
+    const token1_balance_bef_limit_order_market_maker = await token1.balanceOf(marketMaker.address);
+    const token0_balance_bef_limit_order_market_maker = await token0.balanceOf(marketMaker.address);
+
+    const orderBookId: number = 0;
+    const amount0base_limit_order: number = 1;
+    const price0Base_limit_order: number = 1;
+    const isAsk_limit_order: number = 1;
+    const hintId: number = 0;
+
+    // Create 5 ask-limit orders
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 2
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 3
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 4
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 5
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 6
+
+    const token1_balance_aft_limit_order_market_maker = await token1.balanceOf(marketMaker.address);
+    const token0_balance_aft_limit_order_market_maker = await token0.balanceOf(marketMaker.address);
+    
+    //assert the balance of token0 for market-maker
+    //after submitting 5 limit orders (ask - token0) -> with token-amount:1 for each limit-order, 
+    //the balance of token0 for market-maker should decrease by 5 * sizeTick
+    expect(
+      (token0_balance_aft_limit_order_market_maker).eq(
+        BigInt(token0_balance_bef_limit_order_market_maker) - BigInt(5 * sizeTick)
+      )
+    ).to.be.true;
+
+    const token1_balance_bef_mkt_order_market_taker = await token1.balanceOf(marketTaker.address);
+    const token0_balance_bef_mkt_order_market_taker = await token0.balanceOf(marketTaker.address);
+  
+    const amount0base_bid_market_order: number = 6;
+    const price0Base_bid_market_order: number = 1;
+    const isAsk_bid_market_order: number = 0;
+
+    // Create bid-market order to fill first 3 limit-ask orders
+    // market-order to buy token0 of amount: 5 after including size-tick it will be: 6 * 100 = 600
+    await router.connect(marketTaker).createMarketOrder(orderBookId, amount0base_bid_market_order, price0Base_bid_market_order, isAsk_bid_market_order);
+
+    let order_ids = await router.getLimitOrders(0);
+
+    const token0_balance_aft_mkt_order_market_taker = await token0.balanceOf(marketTaker.address);
+    const token1_balance_aft_mkt_order_market_maker = await token1.balanceOf(marketMaker.address);
+    
+    expect(order_ids[0].length).to.equal(0);
+    expect(order_ids[0]).to.deep.equal([]);
+
+    //assert the balance of token0 for market-taker
+    //after matching with 3 limit orders, 
+    //the balance of token0 for market-taker should increase by 500 amount
+    expect(
+      (token0_balance_aft_mkt_order_market_taker).eq(
+        BigInt(token0_balance_bef_mkt_order_market_taker) + BigInt(5 * sizeTick)
+      )
+    ).to.be.true;
+
+    //assert the balance of token1 for market-maker
+    //after matching bid-market-order with 5 ask-limit-orders, 
+    //the balance of token1 for market-maker should increase by 3 amount
+    expect(
+      (token1_balance_aft_mkt_order_market_maker).eq(
+        BigInt(token1_balance_aft_limit_order_market_maker) + BigInt(5 * amount0base_limit_order * price0Base_limit_order * priceMultiplier)
+      )
+    ).to.be.true;
+
+  });
+
 
   it("Market orders tests by filling bid limit orders", async function () {
     const { router, token0, token1, acc1, acc2, sizeTick, priceMultiplier } = await get_setup_values();
@@ -156,19 +231,19 @@ describe("OrderBook contract, market orders", function () {
     const marketMaker = acc2;
     const marketTaker = acc1;
     const orderBookId : number = 0;
-    const amount0base_limit: number = 1;
-    const price0Base_limit: number = 1;
-    const isAsk_limit: number = 0;
+    const amount0base_limit_order: number = 1;
+    const price0Base_limit_order: number = 1;
+    const isAsk_limit_order: number = 0;
     const hintId: number = 0;
 
     const token1_balance_bef_limit_order_market_maker = await token1.balanceOf(marketMaker.address);
 
     // Create 5 bid limit orders
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 2
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 3
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 4
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 5
-    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 6
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 2
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 3
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 4
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 5
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit_order, price0Base_limit_order, isAsk_limit_order, hintId); // 6
 
     const token1_balance_aft_limit_order_market_maker = await token1.balanceOf(marketMaker.address);
 
@@ -181,19 +256,18 @@ describe("OrderBook contract, market orders", function () {
       )
     ).to.be.true;
 
-
     const token1_balance_aft_limit_order_market_taker = await token1.balanceOf(marketTaker.address);
     const token0_balance_aft_limit_order_market_maker = await token0.balanceOf(marketMaker.address);
 
     const token1_balance_bef_mkt_order_market_taker = await token1.balanceOf(marketTaker.address);
     const token0_balance_bef_mkt_order_market_taker = await token0.balanceOf(marketTaker.address);
 
-    const amount0base_ask_market: number = 3;
-    const price0Base_ask_market: number = 1;
-    const isAsk_ask_market: number = 1;
+    const amount0base_ask_market_order: number = 3;
+    const price0Base_ask_market_order: number = 1;
+    const isAsk_ask_market_order: number = 1;
 
     // Create ask-market order to fill first three asks
-    await router.connect(marketTaker).createMarketOrder(orderBookId, amount0base_ask_market, price0Base_ask_market, isAsk_ask_market);
+    await router.connect(marketTaker).createMarketOrder(orderBookId, amount0base_ask_market_order, price0Base_ask_market_order, isAsk_ask_market_order);
 
     let order_ids = await router.getLimitOrders(orderBookId);
 
@@ -218,7 +292,7 @@ describe("OrderBook contract, market orders", function () {
     //the balance of token1 for market-taker should increase by 3 amount
     expect(
       (token1_balance_aft_mkt_order_market_taker).eq(
-        BigInt(token1_balance_aft_limit_order_market_taker) + BigInt(3 * amount0base_limit * price0Base_limit * priceMultiplier)
+        BigInt(token1_balance_aft_limit_order_market_taker) + BigInt(3 * amount0base_limit_order * price0Base_limit_order * priceMultiplier)
       )
     ).to.be.true;
 

--- a/test/MarketOrder.ts
+++ b/test/MarketOrder.ts
@@ -150,19 +150,31 @@ describe("OrderBook contract, market orders", function () {
   });
 
   it("Market orders tests by filling bid limit orders", async function () {
-    const { router, acc1 } = await get_setup_values();
+    const { router, acc1, acc2 } = await get_setup_values();
 
-    // Create 5 ask limit orders
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 0, 0); // 2
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 0, 0); // 3
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 0, 0); // 4
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 0, 0); // 5
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 0, 0); // 6
+    const marketMaker = acc2;
+    const marketTaker = acc1;
+    const orderBookId : number = 0;
+    const amount0base_limit: number = 1;
+    const price0Base_limit: number = 1;
+    const isAsk_limit: number = 0;
+    const hintId: number = 0;
 
-    // Create market order to fill first three asks
-    await router.connect(acc1).createMarketOrder(0, 3, 1, 1);
+    // Create 5 bid limit orders
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 2
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 3
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 4
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 5
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 6
 
-    let order_ids = await router.getLimitOrders(0);
+    const amount0base_ask_market: number = 3;
+    const price0Base_ask_market: number = 1;
+    const isAsk_ask_market: number = 1;
+
+    // Create ask-market order to fill first three asks
+    await router.connect(marketTaker).createMarketOrder(orderBookId, amount0base_ask_market, price0Base_ask_market, isAsk_ask_market);
+
+    let order_ids = await router.getLimitOrders(orderBookId);
 
     expect(order_ids[0].length).to.equal(2);
     expect(order_ids[0]).to.deep.equal([5, 6]);

--- a/test/MarketOrder.ts
+++ b/test/MarketOrder.ts
@@ -59,8 +59,10 @@ describe("OrderBook contract, market orders", function () {
 
     // Create the order book
     const sizeTick = 100; // decimal=3 so multiples of 0.1
-    const priceTick = 10; // decimal=3 so multiples of 0.001
+    const priceTick: number = 10; // decimal=3 so multiples of 0.001
     await factory.createOrderBook(token0.address, token1.address, 2, 1);
+
+    const priceMultiplier = (priceTick * sizeTick) / (10 ** 3);
 
     return {
       router,
@@ -71,26 +73,80 @@ describe("OrderBook contract, market orders", function () {
       acc2,
       sizeTick,
       priceTick,
+      priceMultiplier,
     };
   }
 
-  it("Market orders tests by filling ask limit orders", async function () {
-    const { router, acc1 } = await get_setup_values();
+  it("Bid-Market-Order match with Ask-Limit-Orders", async function () {
+    const { router, token0, token1, acc1, acc2, sizeTick, priceMultiplier } = await get_setup_values();
+    const marketMaker = acc2;
+    const marketTaker = acc1;
+    const td = BigInt(1000000); // token decimals
 
-    // Create 5 ask limit orders
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 1, 0); // 2
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 1, 0); // 3
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 1, 0); // 4
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 1, 0); // 5
-    await router.connect(acc1).createLimitOrder(0, 1, 1, 1, 0); // 6
+    const token1_balance_bef_limit_order_market_maker = await token1.balanceOf(marketMaker.address);
+    const token0_balance_bef_limit_order_market_maker = await token0.balanceOf(marketMaker.address);
 
-    // Create market order to fill first three asks
-    await router.connect(acc1).createMarketOrder(0, 3, 1, 0);
+    const orderBookId: number = 0;
+    const amount0base_limit: number = 1;
+    const price0Base_limit: number = 1;
+    const isAsk_limit: number = 1;
+    const hintId: number = 0;
+
+    // Create 5 ask-limit orders
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 2
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 3
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 4
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 5
+    await router.connect(marketMaker).createLimitOrder(orderBookId, amount0base_limit, price0Base_limit, isAsk_limit, hintId); // 6
+
+    const token1_balance_aft_limit_order_market_maker = await token1.balanceOf(marketMaker.address);
+    const token0_balance_aft_limit_order_market_maker = await token0.balanceOf(marketMaker.address);
+    
+    //assert the balance of token0 for market-maker
+    //after submitting 5 limit orders (ask - token0) -> with token-amount:1 for each limit-order, 
+    //the balance of token0 for market-maker should decrease by 5 * sizeTick
+    expect(
+      (token0_balance_aft_limit_order_market_maker).eq(
+        BigInt(token0_balance_bef_limit_order_market_maker) - BigInt(5 * sizeTick)
+      )
+    ).to.be.true;
+
+    const token1_balance_bef_mkt_order_market_taker = await token1.balanceOf(marketTaker.address);
+    const token0_balance_bef_mkt_order_market_taker = await token0.balanceOf(marketTaker.address);
+  
+    const amount0base_bid_market: number = 3;
+    const price0Base_bid_market: number = 1;
+    const isAsk_bid_market: number = 0;
+
+    // Create bid-market order to fill first 3 limit-ask orders
+    // market-order to buy token0 of amount: 3 after including size-tick it will be: 3 * 100 = 300
+    await router.connect(marketTaker).createMarketOrder(orderBookId, amount0base_bid_market, price0Base_bid_market, isAsk_bid_market);
 
     let order_ids = await router.getLimitOrders(0);
 
+    const token0_balance_aft_mkt_order_market_taker = await token0.balanceOf(marketTaker.address);
+    const token1_balance_aft_mkt_order_market_maker = await token1.balanceOf(marketMaker.address);
+    
     expect(order_ids[0].length).to.equal(2);
     expect(order_ids[0]).to.deep.equal([5, 6]);
+    //assert the balance of token0 for market-taker
+    //after matching with 3 limit orders, 
+    //the balance of token0 for market-taker should increase by 300 amount
+    expect(
+      (token0_balance_aft_mkt_order_market_taker).eq(
+        BigInt(token0_balance_bef_mkt_order_market_taker) + BigInt(3 * sizeTick)
+      )
+    ).to.be.true;
+
+    //assert the balance of token1 for market-maker
+    //after matching bid-market-order with 3 ask-limit-orders, 
+    //the balance of token1 for market-maker should increase by 3 amount
+    expect(
+      (token1_balance_aft_mkt_order_market_maker).eq(
+        BigInt(token1_balance_aft_limit_order_market_maker) + BigInt(3 * amount0base_limit * price0Base_limit * priceMultiplier)
+      )
+    ).to.be.true;
+
   });
 
   it("Market orders tests by filling bid limit orders", async function () {
@@ -112,7 +168,7 @@ describe("OrderBook contract, market orders", function () {
     expect(order_ids[0]).to.deep.equal([5, 6]);
   });
 
-  it("Market order tests with fallback function", async function () {
+  it("Market-Bid order tests with fallback function", async function () {
     const { router, token0, token1, acc1, acc2 } = await get_setup_values();
 
     const tokenAmount = "10000000000000";
@@ -120,6 +176,7 @@ describe("OrderBook contract, market orders", function () {
     const td = BigInt(1000000); // token decimals
     const startBalance = BigInt(tokenAmount);
 
+    //send market-ask order with hintId: 0, amount(token0): 15 tokens at limit-price 1
     await (
       await acc1.sendTransaction({
         to: router.address,
@@ -134,6 +191,7 @@ describe("OrderBook contract, market orders", function () {
       })
     ).wait();
 
+    //send market-ask order with hintId: 1, amount(token0): 25 tokens at limit-price 1
     await (
       await acc1.sendTransaction({
         to: router.address,
@@ -148,6 +206,7 @@ describe("OrderBook contract, market orders", function () {
       })
     ).wait();
 
+    //send market-ask order with hintId: 3, amount(token0): 5 tokens at limit-price 1
     await (
       await acc1.sendTransaction({
         to: router.address,
@@ -162,6 +221,7 @@ describe("OrderBook contract, market orders", function () {
       })
     ).wait();
 
+    //send market-Bid order for 45 token0 tokens (current market price: 1)
     await (
       await acc2.sendTransaction({
         to: router.address,
@@ -174,11 +234,16 @@ describe("OrderBook contract, market orders", function () {
       })
     ).wait();
 
+    //assert the balance of token0 for market-taker
+    //after matching with 3 limit orders, the balance of token0 should increase by 45*100 amount
     expect(
       (await token0.balanceOf(acc2.address)).eq(
         startBalance + BigInt(4500) * td
       )
     ).to.be.true;
+
+    //assert the balance of token1 for market-taker
+    //after matching with 3 limit orders, the balance of token1 should decrease by 15*1+25*1+5*1
     expect(
       (await token1.balanceOf(acc2.address)).eq(startBalance - BigInt(135) * td)
     ).to.be.true;


### PR DESCRIPTION
## Background:

- createMarketOrder() will deduct amount from user to the orderBook 
- match gets initiated followed by refund of any unmatched amount
- this is not optimistic approach because amont computed to be deducted initially from user is by taking max Price of matched orders in orderBook
- this also involves gas Wastage due to additional steps such as refund process after partial matching

## Requirement

- match the market order against the orders in orderBook
- identify the matchable orders on orderBook and amount0, amount1 corresponding to each matched order
- once all matches are identified, loop through each match and do fund transfer between `marketTaker` and `marketMaker`
- no refund is involved in this approach as we deduct only required amount from user based on matched orders and filled Amount in those matches

## Change List:

- matchOrder function is to be refactored in to 2 functions:
    - matchLimitOrder
    - matchMarketOrder

- rename `matchOrder` function to `matchLimitOrder()`
- createNewOrder() to make use of new function `matchMarketOrder()`
- createLimitOrder() to make use of renamed `matchOrder()` to `matchLimitOrder()`




